### PR TITLE
Upgrading actions/setup-python v5 > v5.5.0 & Upgrade to using python 3.11 

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   install-test:
-    runs-on: [self-hosted, linux, flyweight]
+    runs-on: [self-hosted, linux, github-runner-18]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 jobs:
   install-test:
-    runs-on: [self-hosted, linux, github-runner-18]
+    runs-on: [self-hosted, linux, flyweight]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/action.yaml
+++ b/action.yaml
@@ -11,9 +11,9 @@ runs:
   using: "composite"
   steps:
     - name: "Install Python3.10 or Greater"
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v5.5.0
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: "Install Pip Packages"
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -13,7 +13,7 @@ runs:
     - name: "Install Python3.10 or Greater"
       uses: actions/setup-python@v5.5.0
       with:
-        python-version: "3.11"
+        python-version: "3.10"
 
     - name: "Install Pip Packages"
       shell: bash

--- a/action.yaml
+++ b/action.yaml
@@ -13,7 +13,7 @@ runs:
     - name: "Install Python3.10 or Greater"
       uses: actions/setup-python@v5.5.0
       with:
-        python-version: "3.10"
+        python-version: "3.11"
 
     - name: "Install Pip Packages"
       shell: bash


### PR DESCRIPTION
This appears to resolve a bug where after running the setup python action python is unavailable on the tmp path where the virtualenv has been setup. 